### PR TITLE
Update to 'dev' to align with Novela & starter

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build && cp -R _redirects public/",
-    "develop": "gatsby develop",
+    "dev": "gatsby develop",
     "clean": "gatsby clean"
   },
   "dependencies": {


### PR DESCRIPTION
This changes `develop` to `dev` in scripts to align with the 'dev' command used in Novela and Novela starter.